### PR TITLE
0009 - Expose js core modules to the window object to provide an interface to every developers

### DIFF
--- a/0005-expose-js-modules-using-window-variable.md
+++ b/0005-expose-js-modules-using-window-variable.md
@@ -23,7 +23,7 @@ The idea would be to give them the possibility to initialize TranslatableInput u
 
 This means that if they are already initiated, they need to avoid a new execution.
 
-Currently, the `prestashop` object is not used in the BO, but as we wants to stick to the workflow used on FO, we would like to introduce it in the backoffice.
+Currently, the `prestashop` object is not used in the BO, but as we want to stick to the workflow used on FO, we would like to introduce it in the backoffice.
 
 @JevgenijVisockij submited a way of initializing global objects :
 
@@ -45,17 +45,33 @@ const initComponents = () => {
 }
 ```
 
+and used like :
+
+```
+$(() => {
+    window.prestashop.components.translatableInput.init();
+});
+```
+
+and maybe you could get the possibility to access to the component directly like :
+
+```
+$(() => {
+    new window.prestashop.components.translatableInput.component({localeItemSelector: '.my-selector'});
+});
+```
+
 based on a little POC, which was mainly a proof of concept : [20313](https://github.com/PrestaShop/PrestaShop/pull/20313)
 
-This means that we'll have to refacto a lot of javascripts in order to port every components into globals, or atleast begin by mosts used ones.
+This means that we'll have to refacto a lot of javascripts in order to port every components into globals, or at least begin by mosts used ones.
 
 ## Consequences
 
-What become easier :
+What becomes easier :
 
-- As a module developer, you'll be able to use every global javascript features of the core (if they are exposed inside the window objet)
+- As a module developer, you'll be able to use every global javascript features of the core (if they are exposed inside the window object)
 - As a module developer, you're no longer forced to use hard paths breaking your dev environment or CI/CD workflow
-- As a core developer, you're no longer forced to import every modules you need, if they are exposed in the window objet, you'll be able to use them directly
+- As a core developer, you're no longer forced to import every modules you need, if they are exposed in the window object, you'll be able to use them directly
 - We now provide a way to avoid multiple executions of the same feature, while before, every modules was using them as they wants without caring of others modules. It means that we'll maybe avoid some side effects on some features.
 - Modules will be able to override core components without breaking the shop update workflow
 

--- a/0005-expose-js-modules-using-window-variable.md
+++ b/0005-expose-js-modules-using-window-variable.md
@@ -72,7 +72,7 @@ What becomes easier :
 - As a module developer, you'll be able to use every global javascript features of the core (if they are exposed inside the window object)
 - As a module developer, you're no longer forced to use hard paths breaking your dev environment or CI/CD workflow
 - As a core developer, you're no longer forced to import every modules you need, if they are exposed in the window object, you'll be able to use them directly
-- We now provide a way to avoid multiple executions of the same feature, while before, every modules was using them as they wants without caring of others modules. It means that we'll maybe avoid some side effects on some features.
+- We now provide a way to avoid multiple executions of the same feature, while before, every modules was using them as they wants without caring of other modules. It means that we'll maybe avoid some side effects on some features.
 - Modules will be able to override core components without breaking the shop update workflow
 
 What could become harder :

--- a/0005-expose-js-modules-using-window-variable.md
+++ b/0005-expose-js-modules-using-window-variable.md
@@ -1,0 +1,64 @@
+# 5. Expose js modules using window variable
+
+Date: 2020-08-20
+
+## Status
+
+In discussion
+
+## Context
+
+The issue motivating this decision, and any context that influences or constrains the decision.
+Modules are unable to use translatable type without using hardlinks such as :
+
+```
+import TranslatableInput from '../../../../../admin-dev/themes/new-theme/js/components/translatable-input';
+```
+
+This path is making CI/CD harder, and also break on some development environment such as symlinks or containers.
+
+## Decision
+
+The idea would be to give them the possibility to initialize TranslatableInput using a global objet such as `window.prestashop.components.TranslatableInput.init()`.
+
+This means that if they are already initiated, they need to avoid a new execution.
+
+Currently, the `prestashop` object is not used in the BO, but as we wants to stick to the workflow used on FO, we would like to introduce it in the backoffice.
+
+@JevgenijVisockij submited a way of initializing global objects :
+
+```
+const initComponents = () => {
+  let translatableInput = null;
+  window.prestashop = {
+    components: {
+      translatableInput: {
+        init() {
+          if (translatableInput === null) {
+            translatableInput = new TranslatableInput();
+          }
+          return translatableInput;
+        },
+      },
+    }
+  }
+}
+```
+
+based on a little POC, which was mainly a proof of concept : [20313](https://github.com/PrestaShop/PrestaShop/pull/20313)
+
+This means that we'll have to refacto a lot of javascripts in order to port every components into globals, or atleast begin by mosts used ones.
+
+## Consequences
+
+What become easier :
+
+- As a module developer, you'll be able to use every global javascript features of the core (if they are exposed inside the window objet)
+- As a module developer, you're no longer forced to use hard paths breaking your dev environment or CI/CD workflow
+- As a core developer, you're no longer forced to import every modules you need, if they are exposed in the window objet, you'll be able to use them directly
+- We now provide a way to avoid multiple executions of the same feature, while before, every modules was using them as they wants without caring of others modules. It means that we'll maybe avoid some side effects on some features.
+- Modules will be able to override core components without breaking the shop update workflow
+
+What could become harder :
+
+- It will require more knowledge about the project. Before, you needed to know that TranslatableInput exist, while you'll need to also now that they are global and don't require to be imported at all.

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -1,4 +1,4 @@
-# 5. Expose js modules using window variable
+# 9. Expose js components using window variable
 
 Date: 2020-08-20
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -37,7 +37,7 @@ The namespace will contain classes like this `prestashop.component.SomeComponent
 
 Since you have access to both constructors and components, developers are free to choose how to initialize and control their components.
 
-If you don't want to initialize a given component with default parameters, you can always call new `prestashop.component.SomeComponent(...myOwnParameters)`.
+If you don't want to initialize a given component with default parameters, you can always call `new prestashop.component.SomeComponent(...myOwnParameters)`.
 
 If you need to apply some mutation to an already initialized component, you just get the global instance: `prestashop.instance.someComponent.doSomething(...)`.
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -31,7 +31,7 @@ The namespace will contain classes like this `prestashop.component.SomeComponent
 
 3. Reusable components will be available as initialized instances through `window.prestashop.instance`. These instances are initialized with default parameters by the `initComponents` function.
 
-4. A function `initComponent` available through `prestashop.component` is responsible for building `window.prestashop.instance`.
+4. A function `initComponents` available through `prestashop.component` is responsible for building `window.prestashop.instance`.
 
 ### Why a namespace and a collection of instances
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -4,7 +4,7 @@ Date: 2020-08-20
 
 ## Status
 
-Ready for vote
+Accepted
 
 ## Context
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -27,7 +27,7 @@ All PrestaShop components will be bundled together and made available in all pag
 
 2. Reusable components will be available as a namespace `window.prestashop.component`.
 
-The namespace will contain classes like this `prestashop.component.SomeComponent`. If you want to get a new instance of `SomeComponent`, you call new `prestashop.component.SomeComponent(...params)`
+The namespace will contain classes like this `prestashop.component.SomeComponent`. If you want to get a new instance of `SomeComponent`, you call `new prestashop.component.SomeComponent(...params)`
 
 3. Reusable components will be available as initialized instances through `window.prestashop.instance`. These instances are initialized with default parameters.
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -8,8 +8,7 @@ In discussion
 
 ## Context
 
-The issue motivating this decision, and any context that influences or constrains the decision.
-Modules are unable to use translatable type without using hardlinks such as :
+Modules are unable to use translatable type without using hardlinks such as:
 
 ```
 import TranslatableInput from '../../../../../admin-dev/themes/new-theme/js/components/translatable-input';
@@ -19,7 +18,7 @@ This path is making CI/CD harder, and also break on some development environment
 
 ## Decision
 
-The idea would be to give them the possibility to initialize TranslatableInput using a global objet such as `window.prestashop.components.TranslatableInput.init()`.
+Reusable components in BO will be available globally in `window.prestashop.components`, like this: `window.prestashop.components.TranslatableInput.init()`.
 
 This means that if they are already initiated, they need to avoid a new execution.
 
@@ -61,7 +60,7 @@ $(() => {
 });
 ```
 
-based on a little POC, which was mainly a proof of concept : [20313](https://github.com/PrestaShop/PrestaShop/pull/20313)
+based on a little POC: [20313](https://github.com/PrestaShop/PrestaShop/pull/20313)
 
 This means that we'll have to refacto a lot of javascripts in order to port every components into globals, or at least begin by mosts used ones.
 

--- a/0009-expose-js-components-using-window-variable.md
+++ b/0009-expose-js-components-using-window-variable.md
@@ -29,7 +29,7 @@ All PrestaShop components will be bundled together and made available in all pag
 
 The namespace will contain classes like this `prestashop.component.SomeComponent`. If you want to get a new instance of `SomeComponent`, you call `new prestashop.component.SomeComponent(...params)`
 
-3. Reusable components will be available as initialized instances through `window.prestashop.instance`. These instances are initialized with default parameters.
+3. Reusable components will be available as initialized instances through `window.prestashop.instance`. These instances are initialized with default parameters by the `initComponents` function.
 
 4. A function `initComponent` available through `prestashop.component` is responsible for building `window.prestashop.instance`.
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We need to decide about a proper workflow of exposing core js modules to every developers using a global object such as window
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Vote

Maintainer | Vote
---------- | ----
@eternoendless | 
@PierreRambaud | ✅ 
@matks| ✅ 
@jolelievre | ✅ 
@Progi1984 | 
@matthieu-rolland| ✅ 
@atomiix  | 
@NeOMakinG | ✅ 
@sowbiba | 