### PR TITLE
0014 - Drop the "No Use Of Legacy In New Code" restriction

### DIFF
--- a/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
+++ b/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
@@ -4,7 +4,7 @@ Date: 2021-08-25
 
 ## Status
 
-In discussion
+Accepted
 
 ## Context
 

--- a/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
+++ b/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
@@ -8,33 +8,37 @@ In discussion
 
 ## Context
 
-The [original problem]((https://build.prestashop.com/news/new-architecture-1-6-1-0/) was that PrestaShop was made out mainly of static classes, and there was no dependency injection. To adress that problem, it was decided that non namespaced code would be progressively refactored into a `Core` namespace, which would only contain code using with dependency injection. Furthermore, Core code wouldn't be allowed to depend directly on non namespaced classes, but it could to it by the means of `Adapter` classes that would act as a bridge between new and old code.
+Originally, PrestaShop was made out mainly of static classes, with no dependency injection. To address that problem, it [was decided](https://build.prestashop.com/news/new-architecture-1-6-1-0/) that non namespaced code would be progressively refactored into a `Core` namespace, which would only contain code using with dependency injection. Furthermore, Core code wouldn't be allowed to depend directly on non namespaced classes, but it could to it indirectly by the means of `Adapter` classes that would act as a bridge between new and old code.
 
-The "no direct dependency between Core and Legacy" rule led to an ever growing collection of adapters that resulted in greatly increased code complexity and duplication. In some cases, the same service can have a legacy, adapter and core implementations, with subtle differences between each one. Furthermore, the constraints of backward compatibility further increase the difficulties to refactor code into Core, because the suface of the "public API" is larger.
+The "no direct dependency between Core and Legacy" rule led to an ever-growing collection of adapters, which resulted in greatly increased code complexity and duplication. In some cases, the same service can have a legacy, adapter and core implementations, with subtle differences between each one. Furthermore, the constraints of backward compatibility further increase the difficulties to refactor code into Core, because the surface of the "public API" is larger.
 
 ## Decision
 
 The following decision applies to both `Core` and `PrestaShopBundle` classes (referred as to "Core" for shortness):
 
-1. Core classes MAY now depend on instances of legacy classes, provided the following rules are respected:
+1. **All new Core classes SHOULD be placed either in the `Core` or the `PrestaShopBundle` namespace**, following on the rules established previously.
 
-	- Legacy classes MAY be used either as injected parameters or constructed within, but caution must be exerced when using legacy classes that produce side effects, have global state or don't guarantee internal consistency. In those cases, delegating access through dedicated services is still recommended
+   - New classes MUST NOT be added to the `Adapter` namespace, and SHOULD NOT be added to the legacy (root) namespace.
 
-	- Core classes MUST NOT call static methods on other classes, except for factory methods.
+2. **Core classes MAY depend on instances of legacy classes**, provided the following rules are respected:
 
-	- Core classes MUST rely on Application-level services, Repositories or Data Providers as necessary in order to encapsulate access to data provided by static classes or methods.
+    - Legacy classes MAY be used either as injected parameters or constructed within, but caution must be exerted when using legacy classes that produce side effects, have global state or don't guarantee internal consistency. In those cases, these classes SHOULD be accessed through dedicated services which enforce consistency.
 
-2. Core classes MUST NOT reimplement code found in legacy classes, without deprecating the original method/class and making it rely on the new code.
+    - Core classes MUST NOT call static methods on other classes, except for factory methods, stateless tool methods, or within services dedicated to encapsulate a static class.
 
-3. The Adapter namespace will be phased out:
+    - Core classes MAY access to data provided by static classes or methods static classes by relying on dedicated services (Application services, Repositories, Data Providers...).
 
-	- Classes in the Adapter namespace will be copied to the Core namespace.
+3. **Core classes MUST NOT reimplement code found in legacy classes**, without deprecating the original method/class (and optionally, making it rely on the new implementation(.
 
-	- The original Adapter classes will be emptied out, made to extend the Core classes, and deprecated so that they can be fully removed in the next major.
+4. **The Adapter namespace MUST be phased out** eventually:
 
-	- Adapter services must be deprecated and copied into the core namespace as well.
+    - Classes in the Adapter namespace MUST be copied to the Core namespace.
 
-	- No code must depend on Adapter classes or services.
+    - The original Adapter classes MUST be emptied out, made to extend the Core classes, and deprecated so that they can be fully removed in a following major.
+
+    - Adapter services MUST be deprecated and copied into the core namespace as well.
+
+    - Code MUST NOT depend on Adapter classes or services.
 
 ## Consequences
 

--- a/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
+++ b/0014-drop-the-no-use-of-legacy-in-new-code-restriction.md
@@ -28,7 +28,7 @@ The following decision applies to both `Core` and `PrestaShopBundle` classes (re
 
     - Core classes MAY access to data provided by static classes or methods static classes by relying on dedicated services (Application services, Repositories, Data Providers...).
 
-3. **Core classes MUST NOT reimplement code found in legacy classes**, without deprecating the original method/class (and optionally, making it rely on the new implementation(.
+3. **Core classes MUST NOT reimplement code found in legacy classes**, without deprecating the original method/class (and optionally, making it rely on the new implementation).
 
 4. **The Adapter namespace MUST be phased out** eventually:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ADR ID | Date       | Discussion           | Title                              
 0009   | 2020-08-20 | ~                    | [Expose js components using window variable][0009]   | ✅ Accepted
 0010   | 2020-12-15 | [Pull Request][0010] | Module version bump convention when Core is updated  | 💬 In discussion
 0011   | 2021-01-05 | [Pull Request][0011] | Use constants for configuration variables            | 💬 In discussion
-0014   | 2021-08-25 | ~ | Drop the "No Use Of Legacy In New Code" restriction | 💬 In discussion
+0014   | 2021-08-25 | ~                    | [Drop the "No Use Of Legacy In New Code" restriction][0014] | ✅ Accepted
 
 
 
@@ -51,3 +51,4 @@ ADR ID | Date       | Discussion           | Title                              
 [0009]: 0009-expose-js-components-using-window-variable.md
 [0010]: https://github.com/PrestaShop/ADR/pull/14
 [0011]: https://github.com/PrestaShop/ADR/pull/16
+[0014]: 0014-drop-the-no-use-of-legacy-in-new-code-restriction.md


### PR DESCRIPTION
Summary:
- Allow the use of legacy classes in Core / PrestaShopBundle
- Deprecate Adapter namespace

## Vote

Maintainer | Vote (✅  or ❌)
---------- | ----
@atomiix  | ✅
@eternoendless | ✅
@jolelievre | ✅
@kpodemski | ✅
@matks |  ✅ 
@matthieu-rolland | 
@NeOMakinG | ✅
@PierreRambaud | ✅
@Progi1984 | ✅
@PululuK | 
@sowbiba | ✅
